### PR TITLE
Bugfix: TLM container not starting

### DIFF
--- a/tile-level-marker-proxy/tlm-proxy-container/controllers/tlm-proxy.js
+++ b/tile-level-marker-proxy/tlm-proxy-container/controllers/tlm-proxy.js
@@ -18,9 +18,11 @@ const { setCacheValue, getCacheValue } = require('../cache');
 const { Readable } = require('stream');
 
 let imagingClientConfig = {};
-if (process.env.AHI_ENDPOINT) imagingClientConfig.endpoint = AHI_ENDPOINT;
+if (process.env.AHI_ENDPOINT) imagingClientConfig.endpoint = process.env.AHI_ENDPOINT;
 if (process.env.AHI_REGION) {
-    imagingClientConfig.endpoint = AHI_REGION;
+    imagingClientConfig.region = process.env.AHI_REGION;
+} else if (process.env.AWS_REGION) {
+    imagingClientConfig.region = process.env.AWS_REGION;
 } else {
     imagingClientConfig.region = 'us-east-1';
 }


### PR DESCRIPTION
*Issue #, if available:* #62

*Description of changes:* Fixes an issue where the TLM container doesn't start due to a variable that doesn't exist. To determine the HealthImaging region, the container will use the following environment variables, in order:
  * `AHI_REGION` (from `config.ts`)
  * `AWS_REGION` (built-in to the ECS environment)
  * `us-east-1`