### PR TITLE
s3storescp updates

### DIFF
--- a/s3-storescp/requirements.txt
+++ b/s3-storescp/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.66.1
+aws-cdk-lib>=2.136.0
 constructs>=10.0.0,<11.0.0
 boto3>=1.26.82
 setuptools>=67.4.0

--- a/s3-storescp/s3storescp.py
+++ b/s3-storescp/s3storescp.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     App,
     CfnOutput,
     Duration,
+    Environment,
     Stack,
     RemovalPolicy,
     aws_ec2 as ec2,
@@ -241,7 +242,7 @@ S3StoreSCPStack(
     app, 
     cfg.APP_NAME, 
     description=cfg.CFN_STACK_DESCRIPTION, 
-    env={'region':cfg.DEPLOY_REGION}
+    #env={'region':cfg.DEPLOY_REGION}
     
     # If you don't specify 'env', this stack will be environment-agnostic.
     # Account/Region-dependent features and context lookups will not work,
@@ -250,12 +251,12 @@ S3StoreSCPStack(
     # Uncomment the next line to specialize this stack for the AWS Account
     # and Region that are implied by the current CLI configuration.
 
-    #env=cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
+    env=Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
 
     # Uncomment the next line if you know exactly what Account and Region you
     # want to deploy the stack to. */
 
-    #env=cdk.Environment(account='123456789012', region='us-east-1'),
+    #env=Environment(account='123456789012', region='us-east-1'),
 
     # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. The CDK Environment needs to have the account and region set in order for this example to function. This code was commented out, and also referenced a nonexistent "cdk" object (this is often what the CDK library is imported as in Python examples, however that is not done in this case so this is an error). 

To fix this I have 
- imported ENVIRONMENT from the aws_cdk module
- updated the env code to reference it, and uncommented the env code that is most useful for this code example. I have also commented the original env code that does not set a account (An account is needed for this example to work)

2. The original requirements.txt hardcodes a aws-cdk-lib version. The hardcoded version will deploy out of date NodeJS 14 lambdas. As these are deprecated in AWS GovCloud, this results in the Cloudformation failing. 

To fix this I have
- updated the requirements.txt to require a version greater than or equal to the current version of the library. This version deploys Lambdas with a up to date version of NodeJS   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
