### PR TITLE
cross repo pydicom version upgrade from V3 to 3.0.2 and V2 to 2.4.5

### DIFF
--- a/dicom-ingestion-to-s3-healthimaging/gg_component/DIMSEtoS3/requirements.txt
+++ b/dicom-ingestion-to-s3-healthimaging/gg_component/DIMSEtoS3/requirements.txt
@@ -1,4 +1,4 @@
 pydicom>=2.3.0
 boto3>=1.24.70
-pynetdicom>=2.0.2
+pynetdicom>=2.4.5
 sqs-extended-client

--- a/dicom-ingestion-to-s3-healthimaging/lambda_layer/pydicom/requirements.txt
+++ b/dicom-ingestion-to-s3-healthimaging/lambda_layer/pydicom/requirements.txt
@@ -1,2 +1,2 @@
-pydicom==2.2.2
+pydicom==2.4.5
 

--- a/dicomweb-proxy/requirements.txt
+++ b/dicomweb-proxy/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.35.67
 botocore==1.35.67
 Flask==3.1.0
 flask-cors==5.0.0
-pydicom>=3.0.1
+pydicom>=3.0.2
 waitress==3.0.2
 mysql-connector-python>=8.0.33
 requests-toolbelt>=1.0.0


### PR DESCRIPTION
Updating pydicom versions due to https://github.com/pydicom/pydicom/security/advisories/GHSA-v856-2rf8-9f28
